### PR TITLE
Get rid of "kernel is not SEANDROID enforcing" message at boot time

### DIFF
--- a/mkbootimg.mk
+++ b/mkbootimg.mk
@@ -39,6 +39,7 @@ $(INSTALLED_BOOTIMAGE_TARGET): $(MKBOOTIMG) $(INTERNAL_BOOTIMAGE_FILES) $(INSTAL
 	$(call pretty,"Target boot image: $@")
 	$(hide) $(MKBOOTIMG) $(INTERNAL_BOOTIMAGE_ARGS) $(BOARD_MKBOOTIMG_ARGS) --dt $(INSTALLED_DTIMAGE_TARGET) --output $@
 	$(hide) $(call assert-max-image-size,$@,$(BOARD_BOOTIMAGE_PARTITION_SIZE),raw)
+	echo -n "SEANDROIDENFORCE" >> $@
 	@echo -e ${CL_CYN}"Made boot image: $@"${CL_RST}
 
 ## Overload recoveryimg generation: Same as the original, + --dt arg


### PR DESCRIPTION
Signed-off-by: Corinna Vinschen <corinna@vinschen.de>