### PR TITLE
Add Google Assistant to Build.prop and enable it by default.

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -1,2 +1,3 @@
 # Display
 ro.sf.lcd_density=480
+ro.opa.eligible_device=true

--- a/system.prop
+++ b/system.prop
@@ -1,3 +1,5 @@
 # Display
 ro.sf.lcd_density=480
+
+# Enable Google Assistant by default
 ro.opa.eligible_device=true


### PR DESCRIPTION
Since Google Assistant works with Android 7.0 and up, it will be come a decent default feature.

Signed-off-by: Ru Chern Chong <iruchern@gmail.com>